### PR TITLE
Fix bug in identifying faces

### DIFF
--- a/runway.yml
+++ b/runway.yml
@@ -2,7 +2,7 @@ python: 3.6
 cuda: 9.2
 entrypoint: python runway_model.py
 spec:
-  gpu: True
+  gpu: False
   cpu: True
 build_steps:
   - apt-get -y update

--- a/runway_model.py
+++ b/runway_model.py
@@ -79,9 +79,7 @@ def identify_face(model, args):
             label_encodings[0],
             tolerance=args['match_tolerance'])
         faces = [fr_rect_to_pil_rect(item, width, height) for (item, bl) in zip(input_locations, matches) if bl == True]
-#         for i in range(len(matches)):
-#             if matches[i] == True:
-#                 faces.append(fr_rect_to_pil_rect(c[i], width, height))
+
     return { 'results': faces }
 
 detect_faces_output = {

--- a/runway_model.py
+++ b/runway_model.py
@@ -77,8 +77,9 @@ def identify_face(model, args):
             input_encodings,
             label_encodings[0],
             tolerance=args['match_tolerance'])
-        if True in matches:
-            faces = [ fr_rect_to_pil_rect(face, width, height) for face in input_locations ]
+        for i in range(len(matches)):
+            if matches[i] == True:
+                faces.append(fr_rect_to_pil_rect(input_locations[i], width, height))
     return { 'results': faces }
 
 detect_faces_output = {

--- a/runway_model.py
+++ b/runway_model.py
@@ -71,6 +71,7 @@ def identify_face(model, args):
     width = input_arr.shape[1]
     height = input_arr.shape[0]
     results = []
+    faces = []
     if len(input_encodings) > 0 and len(label_encodings) > 0:
         # compare the labeled encoding to each face found in the input image
         matches = face_recognition.compare_faces(

--- a/runway_model.py
+++ b/runway_model.py
@@ -78,9 +78,10 @@ def identify_face(model, args):
             input_encodings,
             label_encodings[0],
             tolerance=args['match_tolerance'])
-        for i in range(len(matches)):
-            if matches[i] == True:
-                faces.append(fr_rect_to_pil_rect(input_locations[i], width, height))
+        faces = [fr_rect_to_pil_rect(item, width, height) for (item, bl) in zip(input_locations, matches) if bl == True]
+#         for i in range(len(matches)):
+#             if matches[i] == True:
+#                 faces.append(fr_rect_to_pil_rect(c[i], width, height))
     return { 'results': faces }
 
 detect_faces_output = {


### PR DESCRIPTION
Currently when you search for someones face, using the **Identify** mode, you get as a result all the faces present, regardless of these being a match. 
The problem was quite simple, if a face matched the labeled face, the whole array of faces was returned, instead of filtering these. I am not sure if what I did is the best, most efficient or most correct way of handling the problem, sorry for my python newbieness, although it works as expected.

Besides this issue, for some reason I was not able to compile it with cuda so I had to disable the GPU in the `.yml` file. 